### PR TITLE
Add logback support for eclipselink.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,17 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.extension</artifactId>
+      <version>${eclipselink.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.persistence</groupId>
+          <artifactId>org.eclipse.persistence.core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
To enabled logback for EclipseLink, need to add these configuration items to act properties:

db.default.eclipselink.logging.logger=org.eclipse.persistence.logging.slf4j.SLF4JLogger
db.default.eclipselink.logging.level.sql=fine
db.default.eclipselink.logging.parameters=true
db.default.eclipselink.logging.timestamp=true